### PR TITLE
Upgrade to .NET10 and strengthen logging.

### DIFF
--- a/Interfaces/SpecMetrixInterfaces/SpecMetrix.Interfaces/IDataService.cs
+++ b/Interfaces/SpecMetrixInterfaces/SpecMetrix.Interfaces/IDataService.cs
@@ -1,22 +1,34 @@
-﻿namespace SpecMetrix.Interfaces
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SpecMetrix.Interfaces
 {
-    public interface IDataService
+    /// <summary>
+    /// Generic data service for log persistence.
+    /// 
+    /// IMPORTANT:
+    /// This interface remains in SpecMetrix.Interfaces and must NOT depend on SpecMetrix.Shared,
+    /// otherwise you will create a circular dependency (Shared.Logging already depends on Interfaces).
+    /// 
+    /// Consumers should inject IDataService<MongoLogEntry> in .NET 10 services.
+    /// </summary>
+    public interface IDataService<TLogEntry> where TLogEntry : ILogEntry
     {
         /// <summary>
         /// Writes a single log entry to the database.
         /// </summary>
-        Task WriteLogAsync(ILogEntry logEntry);
-
+        Task WriteLogAsync(TLogEntry logEntry);
 
         /// <summary>
-        /// Batch Write log entries to the database.
+        /// Batch write log entries to the database.
         /// </summary>
-        Task WriteLogsAsync(IEnumerable<ILogEntry> logEntries);
+        Task WriteLogsAsync(IEnumerable<TLogEntry> logEntries);
 
         /// <summary>
         /// Retrieves logs with optional query filters.
         /// </summary>
-        Task<IEnumerable<ILogEntry>> ReadLogsAsync(LogQueryOptions queryOptions);
+        Task<IEnumerable<TLogEntry>> ReadLogsAsync(LogQueryOptions queryOptions);
     }
 
     /// <summary>
@@ -28,7 +40,7 @@
         public DateTime? EndDate { get; set; } // Filter logs up to an end date
         public LogLevel? LogLevel { get; set; } // Filter by log level
         public string? Process { get; set; } // Filter by process name (e.g., "Database", "Core")
-        public LogCategory? Category { get; set; } // 
+        public LogCategory? Category { get; set; } //
         public string? Source { get; set; }
         public int? Code { get; set; }
         public string? ClassMethod { get; set; }

--- a/Interfaces/SpecMetrixInterfaces/SpecMetrix.Interfaces/ILogEntry.cs
+++ b/Interfaces/SpecMetrixInterfaces/SpecMetrix.Interfaces/ILogEntry.cs
@@ -3,6 +3,11 @@
 public interface ILogEntry
 {
     /// <summary>
+    /// Event Identifier 
+    /// </summary>
+    string? EventId { get; set; }
+
+    /// <summary>
     /// Unique identifier for the log entry
     /// </summary>
     Guid LogId { get; set; }

--- a/Interfaces/SpecMetrixInterfaces/SpecMetrix.Interfaces/SpecMetrix.Interfaces.csproj
+++ b/Interfaces/SpecMetrixInterfaces/SpecMetrix.Interfaces/SpecMetrix.Interfaces.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
 	<!-- NuGet Package Info -->
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageId>SpecMetrix.Interfaces</PackageId>
-	<Version>0.1.11</Version>
+	<Version>0.1.12</Version>
 	<Authors>Jason Jelks</Authors>
 	<Company>SpecMetrix</Company>
 	<Description>Interfaces for SpecMetrix Logging System</Description>

--- a/LoggingService/SpecMetrixLoggingSystem/LoggingService.Configuration/LoggingService.Configuration.csproj
+++ b/LoggingService/SpecMetrixLoggingSystem/LoggingService.Configuration/LoggingService.Configuration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/LoggingService/SpecMetrixLoggingSystem/LoggingService.Extensions/LoggingService.Extensions.csproj
+++ b/LoggingService/SpecMetrixLoggingSystem/LoggingService.Extensions/LoggingService.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
@@ -27,12 +27,20 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
-		<PackageReference Include="Serilog" Version="4.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.2" />
+		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.Deduplication" Version="1.0.2" />
-		<PackageReference Include="SpecMetrix.Shared" Version="0.1.11" />
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <Reference Include="SpecMetrix.Interfaces">
+	    <HintPath>..\..\..\Interfaces\SpecMetrixInterfaces\SpecMetrix.Interfaces\bin\Release\net10.0\SpecMetrix.Interfaces.dll</HintPath>
+	  </Reference>
+	  <Reference Include="SpecMetrix.Shared">
+	    <HintPath>..\..\..\Shared\SpecMetrixShared\SpecMetrix.Shared\bin\Release\net10.0\SpecMetrix.Shared.dll</HintPath>
+	  </Reference>
 	</ItemGroup>
 
 </Project>

--- a/LoggingService/SpecMetrixLoggingSystem/LoggingService.Extensions/Services/SerilogWrapperService.cs
+++ b/LoggingService/SpecMetrixLoggingSystem/LoggingService.Extensions/Services/SerilogWrapperService.cs
@@ -1,60 +1,101 @@
-﻿using SpecMetrix.Interfaces;
+﻿using System;
+using System.Collections.Generic;
 using LoggingService.Extensions.Interfaces;
+using SpecMetrix.Interfaces;
+using SpecMetrix.Shared.Logging;
 
 namespace LoggingService.Extensions.Services
 {
-
     public class SerilogWrapperService : ISerilogWrapper
     {
         public void Log(ILogEntry logEntry)
         {
+            if (logEntry == null) return;
+
+            var eventId = ResolveEventId(logEntry);
+
             var logger = Serilog.Log.ForContext("Namespace", logEntry.Namespace ?? string.Empty)
+                                    .ForContext("EventId", eventId ?? string.Empty)
                                     .ForContext("Code", logEntry.Code)
                                     .ForContext("Process", logEntry.Process)
                                     .ForContext("Category", logEntry.Category)
                                     .ForContext("Source", logEntry.Source)
                                     .ForContext("DeviceName", logEntry.DeviceName)
                                     .ForContext("MachineName", logEntry.MachineName ?? string.Empty)
-                                    .ForContext("ClassMethod", logEntry.ClassMethod)
-                                    .ForContext("TemplateValues", logEntry.TemplateValues);
+                                    .ForContext("ClassMethod", logEntry.ClassMethod);
 
-            bool hasStructuredValues = logEntry.TemplateValues != null && logEntry.TemplateValues.Count > 0;
+            if (logEntry.TemplateValues != null && logEntry.TemplateValues.Count > 0)
+            {
+                logger = logger.ForContext("TemplateValues", logEntry.TemplateValues, destructureObjects: true);
+            }
 
-            string renderedMessage = RenderMessageTemplate(logEntry.MessageTemplate, logEntry.TemplateValues, logEntry.Message);
-            string template = logEntry.MessageTemplate ?? renderedMessage;
+            if (logEntry.Metadata != null && logEntry.Metadata.Count > 0)
+            {
+                logger = logger.ForContext("Metadata", logEntry.Metadata, destructureObjects: true);
+            }
 
-            object[] values = hasStructuredValues
-                ? logEntry.TemplateValues.Values.ToArray()
-                : Array.Empty<object>();
+            // Render message deterministically. Do NOT pass dictionary values as Serilog args:
+            // - ordering is undefined
+            // - binding won't match template property names
+            var renderedMessage = RenderMessageTemplate(logEntry.MessageTemplate, logEntry.TemplateValues, logEntry.Message);
+            if (string.IsNullOrWhiteSpace(renderedMessage))
+            {
+                renderedMessage = logEntry.MessageTemplate ?? string.Empty;
+            }
 
             switch (logEntry.Level)
             {
                 case LogLevel.Critical:
-                    if (hasStructuredValues) logger.Fatal(template, values); else logger.Fatal(renderedMessage);
+                    logger.Fatal("{Message}", renderedMessage);
                     break;
                 case LogLevel.Error:
-                    if (hasStructuredValues) logger.Error(template, values); else logger.Error(renderedMessage);
+                    logger.Error("{Message}", renderedMessage);
                     break;
                 case LogLevel.Warning:
-                    if (hasStructuredValues) logger.Warning(template, values); else logger.Warning(renderedMessage);
+                    logger.Warning("{Message}", renderedMessage);
                     break;
                 case LogLevel.Debug:
-                    if (hasStructuredValues) logger.Debug(template, values); else logger.Debug(renderedMessage);
+                    logger.Debug("{Message}", renderedMessage);
                     break;
                 case LogLevel.Trace:
-                    if (hasStructuredValues) logger.Verbose(template, values); else logger.Verbose(renderedMessage);
+                    logger.Verbose("{Message}", renderedMessage);
                     break;
                 default:
-                    if (hasStructuredValues) logger.Information(template, values); else logger.Information(renderedMessage);
+                    logger.Information("{Message}", renderedMessage);
                     break;
             }
         }
 
+        private static string? ResolveEventId(ILogEntry e)
+        {
+            // Prefer first-class EventId if present (new .NET services)
+            try
+            {
+                var p = e.GetType().GetProperty("EventId");
+                if (p != null)
+                {
+                    var v = p.GetValue(e, null) as string;
+                    if (!string.IsNullOrWhiteSpace(v)) return v;
+                }
+            }
+            catch { }
 
-        private string RenderMessageTemplate(string template, IDictionary<string, object>? values, string originalMessage)
+            // Fallback: Metadata["eventId"]
+            if (e.Metadata != null &&
+                e.Metadata.TryGetValue("eventId", out var ev) &&
+                ev != null)
+            {
+                var s = ev.ToString();
+                if (!string.IsNullOrWhiteSpace(s)) return s;
+            }
+
+            return null;
+        }
+
+        private static string RenderMessageTemplate(string? template, IDictionary<string, object>? values, string? originalMessage)
         {
             if (string.IsNullOrWhiteSpace(template) || values == null || values.Count == 0)
-                return originalMessage;
+                return originalMessage ?? string.Empty;
 
             foreach (var value in values)
                 template = template.Replace("{" + value.Key + "}", value.Value?.ToString() ?? string.Empty);

--- a/LoggingService/SpecMetrixLoggingSystem/LoggingServiceSetup/LoggingServiceSetup.vdproj
+++ b/LoggingService/SpecMetrixLoggingSystem/LoggingServiceSetup/LoggingServiceSetup.vdproj
@@ -13,12 +13,6 @@
 "SccProvider" = "8:"
     "Hierarchy"
     {
-        "Entry"
-        {
-        "MsmKey" = "8:_670F476CDA9D46D6BD301096F75C20B7"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
     }
     "Configurations"
     {
@@ -37,22 +31,6 @@
         "PrivateKeyFile" = "8:"
         "TimeStampServer" = "8:"
         "InstallerBootstrapper" = "3:2"
-            "BootstrapperCfg:{63ACBE69-63AA-4F98-B2B6-99F9E24495F2}"
-            {
-            "Enabled" = "11:TRUE"
-            "PromptEnabled" = "11:TRUE"
-            "PrerequisitesLocation" = "2:1"
-            "Url" = "8:"
-            "ComponentsUrl" = "8:"
-                "Items"
-                {
-                    "{EDC2488A-8267-493A-A98E-7D9C3B36CDF3}:.NETFramework,Version=v4.7.2"
-                    {
-                    "Name" = "8:Microsoft .NET Framework 4.7.2 (x86 and x64)"
-                    "ProductCode" = "8:.NETFramework,Version=v4.7.2"
-                    }
-                }
-            }
         }
         "Release"
         {
@@ -69,22 +47,6 @@
         "PrivateKeyFile" = "8:"
         "TimeStampServer" = "8:"
         "InstallerBootstrapper" = "3:2"
-            "BootstrapperCfg:{63ACBE69-63AA-4F98-B2B6-99F9E24495F2}"
-            {
-            "Enabled" = "11:TRUE"
-            "PromptEnabled" = "11:TRUE"
-            "PrerequisitesLocation" = "2:1"
-            "Url" = "8:"
-            "ComponentsUrl" = "8:"
-                "Items"
-                {
-                    "{EDC2488A-8267-493A-A98E-7D9C3B36CDF3}:.NETFramework,Version=v4.7.2"
-                    {
-                    "Name" = "8:Microsoft .NET Framework 4.7.2 (x86 and x64)"
-                    "ProductCode" = "8:.NETFramework,Version=v4.7.2"
-                    }
-                }
-            }
         }
     }
     "Deployable"
@@ -102,7 +64,7 @@
         {
             "LaunchCondition"
             {
-                "{A06ECF26-33A3-4562-8140-9B0E340D4F24}:_F28CA121523847E7AC2EE177E0E2A001"
+                "{A06ECF26-33A3-4562-8140-9B0E340D4F24}:_E35CE07FDB674FE797952AACE86C3356"
                 {
                 "Name" = "8:.NET Core"
                 "Message" = "8:[VSDNETCOREMSG]"
@@ -122,7 +84,19 @@
         }
         "Folder"
         {
-            "{1525181F-901A-416C-8A58-119130FE478E}:_02A19D0EB30B426381E8849109E0A0DD"
+            "{3C67513D-01DD-4637-8A68-80971EB9504F}:_59C5D411CCE049F49EA4414CF3C44719"
+            {
+            "DefaultLocation" = "8:[ProgramFiles64Folder][Manufacturer]\\[ProductName]"
+            "Name" = "8:#1925"
+            "AlwaysCreate" = "11:FALSE"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Property" = "8:TARGETDIR"
+                "Folders"
+                {
+                }
+            }
+            "{1525181F-901A-416C-8A58-119130FE478E}:_76A360826876473088487C8B803CE4B0"
             {
             "Name" = "8:#1919"
             "AlwaysCreate" = "11:FALSE"
@@ -133,25 +107,13 @@
                 {
                 }
             }
-            "{1525181F-901A-416C-8A58-119130FE478E}:_B82A62BF57F0424287F98A1B0BC1F39B"
+            "{1525181F-901A-416C-8A58-119130FE478E}:_E4924E1DD2F043EC9581A90DA2DD0D46"
             {
             "Name" = "8:#1916"
             "AlwaysCreate" = "11:FALSE"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Property" = "8:DesktopFolder"
-                "Folders"
-                {
-                }
-            }
-            "{3C67513D-01DD-4637-8A68-80971EB9504F}:_D0C9CA303A0B4F9B98A8DCAAAC3BC325"
-            {
-            "DefaultLocation" = "8:[ProgramFiles64Folder][Manufacturer]\\[ProductName]"
-            "Name" = "8:#1925"
-            "AlwaysCreate" = "11:FALSE"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Property" = "8:TARGETDIR"
                 "Folders"
                 {
                 }
@@ -172,24 +134,24 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:LoggingService"
-        "ProductCode" = "8:{80341C06-B633-4121-AEA0-CEDF51C4629F}"
-        "PackageCode" = "8:{DF8B8550-D1E9-4B5D-B694-D1260DB2C716}"
-        "UpgradeCode" = "8:{F0586D5E-89BB-4628-B0E0-6BD922930E21}"
+        "ProductCode" = "8:{CFF5DE25-B31F-4C72-907C-C58CC5A344C2}"
+        "PackageCode" = "8:{ABC00F8C-C094-490B-8382-AD387A57FFBD}"
+        "UpgradeCode" = "8:{462CD62A-8DB2-4617-87BE-132653535FF6}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
-        "InstallAllUsers" = "11:TRUE"
-        "ProductVersion" = "8:1.0.4"
+        "InstallAllUsers" = "11:FALSE"
+        "ProductVersion" = "8:2.0.0"
         "Manufacturer" = "8:IndustrialPhysics"
-        "ARPHELPTELEPHONE" = "8:+1 336 315 6090"
-        "ARPHELPLINK" = "8:https://industrialphysics.com/brands/specmetrix/"
-        "Title" = "8:Logging Service Setup"
-        "Subject" = "8:SpecMetrix Logging Service"
-        "ARPCONTACT" = "8:IndustrialPhysics"
-        "Keywords" = "8:SpecMetrix Logging"
-        "ARPCOMMENTS" = "8:.NET8 SpecMetrix Logging service with https log entry feed for historical version compatibility"
-        "ARPURLINFOABOUT" = "8:https://industrialphysics.com/brands/specmetrix/"
+        "ARPHELPTELEPHONE" = "8:+13363156090"
+        "ARPHELPLINK" = "8:www.industrialphysics.com"
+        "Title" = "8:LoggingServiceSetup"
+        "Subject" = "8:"
+        "ARPCONTACT" = "8:Jason Jelks"
+        "Keywords" = "8:"
+        "ARPCOMMENTS" = "8:.NET10 SpecMetrix Logging Service"
+        "ARPURLINFOABOUT" = "8:www.industrialphysics.com"
         "ARPPRODUCTICON" = "8:"
         "ARPIconIndex" = "3:0"
         "SearchPath" = "8:"
@@ -205,7 +167,7 @@
             {
                 "Keys"
                 {
-                    "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_5C0808C4E9204DD0A638190A9F4B7221"
+                    "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_405CF94A6FFC41A1B26D41DA78C033B9"
                     {
                     "Name" = "8:Software"
                     "Condition" = "8:"
@@ -214,7 +176,7 @@
                     "Transitive" = "11:FALSE"
                         "Keys"
                         {
-                            "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_D0132590CE9D4019975D12F57129EBD3"
+                            "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_A89C29FE85D74857A321D5AAF770DC8F"
                             {
                             "Name" = "8:[Manufacturer]"
                             "Condition" = "8:"
@@ -239,7 +201,7 @@
             {
                 "Keys"
                 {
-                    "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_808E959FD8F947699C25B30747E099B1"
+                    "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_13AC36B965914DBDAAC6430D8B1DABC7"
                     {
                     "Name" = "8:Software"
                     "Condition" = "8:"
@@ -248,7 +210,7 @@
                     "Transitive" = "11:FALSE"
                         "Keys"
                         {
-                            "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_4F341F1FA74B4CDE9A8A58B40199D9E2"
+                            "{60EA8692-D2D5-43EB-80DC-7906BF13D6EF}:_E3788F1E2FD4459E845329B9282B7DDC"
                             {
                             "Name" = "8:[Manufacturer]"
                             "Condition" = "8:"
@@ -296,14 +258,14 @@
         }
         "UserInterface"
         {
-            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_0AF6899AD99D4B2995A9EBD77C0548EC"
+            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_0A93C89C89E64985911C5BDDE3A68833"
             {
             "Name" = "8:#1902"
             "Sequence" = "3:2"
             "Attributes" = "3:3"
                 "Dialogs"
                 {
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_1CE51C57BBE14EE8AE87C497F80407E5"
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_2D67831D8F6E4830B3CE6307BA75C3C0"
                     {
                     "Sequence" = "3:100"
                     "DisplayName" = "8:Finished"
@@ -327,158 +289,26 @@
                     }
                 }
             }
-            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_2C5EA8C54EAB49BCA14DF735235A71FC"
-            {
-            "Name" = "8:#1901"
-            "Sequence" = "3:1"
-            "Attributes" = "3:2"
-                "Dialogs"
-                {
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_346E2BD7A8304EF1BDEDBD1A206DEE6C"
-                    {
-                    "Sequence" = "3:100"
-                    "DisplayName" = "8:Progress"
-                    "UseDynamicProperties" = "11:TRUE"
-                    "IsDependency" = "11:FALSE"
-                    "SourcePath" = "8:<VsdDialogDir>\\VsdProgressDlg.wid"
-                        "Properties"
-                        {
-                            "BannerBitmap"
-                            {
-                            "Name" = "8:BannerBitmap"
-                            "DisplayName" = "8:#1001"
-                            "Description" = "8:#1101"
-                            "Type" = "3:8"
-                            "ContextData" = "8:Bitmap"
-                            "Attributes" = "3:4"
-                            "Setting" = "3:1"
-                            "UsePlugInResources" = "11:TRUE"
-                            }
-                            "ShowProgress"
-                            {
-                            "Name" = "8:ShowProgress"
-                            "DisplayName" = "8:#1009"
-                            "Description" = "8:#1109"
-                            "Type" = "3:5"
-                            "ContextData" = "8:1;True=1;False=0"
-                            "Attributes" = "3:0"
-                            "Setting" = "3:0"
-                            "Value" = "3:1"
-                            "DefaultValue" = "3:1"
-                            "UsePlugInResources" = "11:TRUE"
-                            }
-                        }
-                    }
-                }
-            }
-            "{2479F3F5-0309-486D-8047-8187E2CE5BA0}:_4059575D64594E43A425B9700ECED1D1"
-            {
-            "UseDynamicProperties" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "SourcePath" = "8:<VsdDialogDir>\\VsdUserInterface.wim"
-            }
-            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_98C0F3F7106B4B8997ABBDFC52753B18"
-            {
-            "Name" = "8:#1902"
-            "Sequence" = "3:1"
-            "Attributes" = "3:3"
-                "Dialogs"
-                {
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_79EB49A53BEB4D198D7DF8F19FB02ED2"
-                    {
-                    "Sequence" = "3:100"
-                    "DisplayName" = "8:Finished"
-                    "UseDynamicProperties" = "11:TRUE"
-                    "IsDependency" = "11:FALSE"
-                    "SourcePath" = "8:<VsdDialogDir>\\VsdFinishedDlg.wid"
-                        "Properties"
-                        {
-                            "BannerBitmap"
-                            {
-                            "Name" = "8:BannerBitmap"
-                            "DisplayName" = "8:#1001"
-                            "Description" = "8:#1101"
-                            "Type" = "3:8"
-                            "ContextData" = "8:Bitmap"
-                            "Attributes" = "3:4"
-                            "Setting" = "3:1"
-                            "UsePlugInResources" = "11:TRUE"
-                            }
-                            "UpdateText"
-                            {
-                            "Name" = "8:UpdateText"
-                            "DisplayName" = "8:#1058"
-                            "Description" = "8:#1158"
-                            "Type" = "3:15"
-                            "ContextData" = "8:"
-                            "Attributes" = "3:0"
-                            "Setting" = "3:1"
-                            "Value" = "8:#1258"
-                            "DefaultValue" = "8:#1258"
-                            "UsePlugInResources" = "11:TRUE"
-                            }
-                        }
-                    }
-                }
-            }
-            "{2479F3F5-0309-486D-8047-8187E2CE5BA0}:_B6B4BB2F97BF48B6A60C6E59363B7824"
+            "{2479F3F5-0309-486D-8047-8187E2CE5BA0}:_19FED65544FF45E2A84197569C59E3B5"
             {
             "UseDynamicProperties" = "11:FALSE"
             "IsDependency" = "11:FALSE"
             "SourcePath" = "8:<VsdDialogDir>\\VsdBasicDialogs.wim"
             }
-            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_CDAD6A97E6804A1D8FC830646C55AFE5"
+            "{2479F3F5-0309-486D-8047-8187E2CE5BA0}:_341959F1B01647F2BDBC72E13019AE3A"
             {
-            "Name" = "8:#1901"
-            "Sequence" = "3:2"
-            "Attributes" = "3:2"
-                "Dialogs"
-                {
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_E815861A2CF844A59C70424AE376A355"
-                    {
-                    "Sequence" = "3:100"
-                    "DisplayName" = "8:Progress"
-                    "UseDynamicProperties" = "11:TRUE"
-                    "IsDependency" = "11:FALSE"
-                    "SourcePath" = "8:<VsdDialogDir>\\VsdAdminProgressDlg.wid"
-                        "Properties"
-                        {
-                            "BannerBitmap"
-                            {
-                            "Name" = "8:BannerBitmap"
-                            "DisplayName" = "8:#1001"
-                            "Description" = "8:#1101"
-                            "Type" = "3:8"
-                            "ContextData" = "8:Bitmap"
-                            "Attributes" = "3:4"
-                            "Setting" = "3:1"
-                            "UsePlugInResources" = "11:TRUE"
-                            }
-                            "ShowProgress"
-                            {
-                            "Name" = "8:ShowProgress"
-                            "DisplayName" = "8:#1009"
-                            "Description" = "8:#1109"
-                            "Type" = "3:5"
-                            "ContextData" = "8:1;True=1;False=0"
-                            "Attributes" = "3:0"
-                            "Setting" = "3:0"
-                            "Value" = "3:1"
-                            "DefaultValue" = "3:1"
-                            "UsePlugInResources" = "11:TRUE"
-                            }
-                        }
-                    }
-                }
+            "UseDynamicProperties" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "SourcePath" = "8:<VsdDialogDir>\\VsdUserInterface.wim"
             }
-            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_F14211E093BA4FBF9F253F722418C01F"
+            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_42501AC2B8454142872471E5D4ECA292"
             {
             "Name" = "8:#1900"
             "Sequence" = "3:2"
             "Attributes" = "3:1"
                 "Dialogs"
                 {
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_2F0B33EA7CC642A9BB1EA8E0A5690DC8"
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_0F3716AEBBDD4B2B91E65E5AF95D0BA6"
                     {
                     "Sequence" = "3:100"
                     "DisplayName" = "8:Welcome"
@@ -526,29 +356,7 @@
                             }
                         }
                     }
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_678A6846F6D747CEB57E30B6588B5613"
-                    {
-                    "Sequence" = "3:200"
-                    "DisplayName" = "8:Installation Folder"
-                    "UseDynamicProperties" = "11:TRUE"
-                    "IsDependency" = "11:FALSE"
-                    "SourcePath" = "8:<VsdDialogDir>\\VsdAdminFolderDlg.wid"
-                        "Properties"
-                        {
-                            "BannerBitmap"
-                            {
-                            "Name" = "8:BannerBitmap"
-                            "DisplayName" = "8:#1001"
-                            "Description" = "8:#1101"
-                            "Type" = "3:8"
-                            "ContextData" = "8:Bitmap"
-                            "Attributes" = "3:4"
-                            "Setting" = "3:1"
-                            "UsePlugInResources" = "11:TRUE"
-                            }
-                        }
-                    }
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_B3C734E986BB4EE7BEE7102B63A6EB43"
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_4DC8E1CF4DAB49C6A77DB9799E77DFF4"
                     {
                     "Sequence" = "3:300"
                     "DisplayName" = "8:Confirm Installation"
@@ -570,22 +378,13 @@
                             }
                         }
                     }
-                }
-            }
-            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_FB44010A153B4E279BB381AE03B74226"
-            {
-            "Name" = "8:#1900"
-            "Sequence" = "3:1"
-            "Attributes" = "3:1"
-                "Dialogs"
-                {
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_355E7EB6237D469FA5CC8163052B2AEB"
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_AB9A790333A1474FB8C16743DF9E9D18"
                     {
-                    "Sequence" = "3:300"
-                    "DisplayName" = "8:Confirm Installation"
+                    "Sequence" = "3:200"
+                    "DisplayName" = "8:Installation Folder"
                     "UseDynamicProperties" = "11:TRUE"
                     "IsDependency" = "11:FALSE"
-                    "SourcePath" = "8:<VsdDialogDir>\\VsdConfirmDlg.wid"
+                    "SourcePath" = "8:<VsdDialogDir>\\VsdAdminFolderDlg.wid"
                         "Properties"
                         {
                             "BannerBitmap"
@@ -601,7 +400,16 @@
                             }
                         }
                     }
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_A6768AEF5DA24CB2AC7AC1AEC6468928"
+                }
+            }
+            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_4DBDD079118246659DFE48FB747F7217"
+            {
+            "Name" = "8:#1900"
+            "Sequence" = "3:1"
+            "Attributes" = "3:1"
+                "Dialogs"
+                {
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_81CB2C26A29346E3A332891B8D4FF9FE"
                     {
                     "Sequence" = "3:200"
                     "DisplayName" = "8:Installation Folder"
@@ -636,7 +444,7 @@
                             }
                         }
                     }
-                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_B4785AB2C9AF4712A9E53BCA86BFF0EB"
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_E4EC9C60890A47189513ABEC83AF4C05"
                     {
                     "Sequence" = "3:100"
                     "DisplayName" = "8:Welcome"
@@ -684,6 +492,160 @@
                             }
                         }
                     }
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_E8EDD96792C342C88BF9D7CDCA1E1FE4"
+                    {
+                    "Sequence" = "3:300"
+                    "DisplayName" = "8:Confirm Installation"
+                    "UseDynamicProperties" = "11:TRUE"
+                    "IsDependency" = "11:FALSE"
+                    "SourcePath" = "8:<VsdDialogDir>\\VsdConfirmDlg.wid"
+                        "Properties"
+                        {
+                            "BannerBitmap"
+                            {
+                            "Name" = "8:BannerBitmap"
+                            "DisplayName" = "8:#1001"
+                            "Description" = "8:#1101"
+                            "Type" = "3:8"
+                            "ContextData" = "8:Bitmap"
+                            "Attributes" = "3:4"
+                            "Setting" = "3:1"
+                            "UsePlugInResources" = "11:TRUE"
+                            }
+                        }
+                    }
+                }
+            }
+            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_9428949837084F86AFD81A034C8ADA54"
+            {
+            "Name" = "8:#1901"
+            "Sequence" = "3:2"
+            "Attributes" = "3:2"
+                "Dialogs"
+                {
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_0EFAB369127F478580C3E1CD9C286CCE"
+                    {
+                    "Sequence" = "3:100"
+                    "DisplayName" = "8:Progress"
+                    "UseDynamicProperties" = "11:TRUE"
+                    "IsDependency" = "11:FALSE"
+                    "SourcePath" = "8:<VsdDialogDir>\\VsdAdminProgressDlg.wid"
+                        "Properties"
+                        {
+                            "BannerBitmap"
+                            {
+                            "Name" = "8:BannerBitmap"
+                            "DisplayName" = "8:#1001"
+                            "Description" = "8:#1101"
+                            "Type" = "3:8"
+                            "ContextData" = "8:Bitmap"
+                            "Attributes" = "3:4"
+                            "Setting" = "3:1"
+                            "UsePlugInResources" = "11:TRUE"
+                            }
+                            "ShowProgress"
+                            {
+                            "Name" = "8:ShowProgress"
+                            "DisplayName" = "8:#1009"
+                            "Description" = "8:#1109"
+                            "Type" = "3:5"
+                            "ContextData" = "8:1;True=1;False=0"
+                            "Attributes" = "3:0"
+                            "Setting" = "3:0"
+                            "Value" = "3:1"
+                            "DefaultValue" = "3:1"
+                            "UsePlugInResources" = "11:TRUE"
+                            }
+                        }
+                    }
+                }
+            }
+            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_A8E1DE9E8E154C21BBC4F6A18A56CD2D"
+            {
+            "Name" = "8:#1901"
+            "Sequence" = "3:1"
+            "Attributes" = "3:2"
+                "Dialogs"
+                {
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_907EE2363B1B4E3A81C4B3FAB5EA0039"
+                    {
+                    "Sequence" = "3:100"
+                    "DisplayName" = "8:Progress"
+                    "UseDynamicProperties" = "11:TRUE"
+                    "IsDependency" = "11:FALSE"
+                    "SourcePath" = "8:<VsdDialogDir>\\VsdProgressDlg.wid"
+                        "Properties"
+                        {
+                            "BannerBitmap"
+                            {
+                            "Name" = "8:BannerBitmap"
+                            "DisplayName" = "8:#1001"
+                            "Description" = "8:#1101"
+                            "Type" = "3:8"
+                            "ContextData" = "8:Bitmap"
+                            "Attributes" = "3:4"
+                            "Setting" = "3:1"
+                            "UsePlugInResources" = "11:TRUE"
+                            }
+                            "ShowProgress"
+                            {
+                            "Name" = "8:ShowProgress"
+                            "DisplayName" = "8:#1009"
+                            "Description" = "8:#1109"
+                            "Type" = "3:5"
+                            "ContextData" = "8:1;True=1;False=0"
+                            "Attributes" = "3:0"
+                            "Setting" = "3:0"
+                            "Value" = "3:1"
+                            "DefaultValue" = "3:1"
+                            "UsePlugInResources" = "11:TRUE"
+                            }
+                        }
+                    }
+                }
+            }
+            "{DF760B10-853B-4699-99F2-AFF7185B4A62}:_D24B0701EF8140A695AA9343AA535BB9"
+            {
+            "Name" = "8:#1902"
+            "Sequence" = "3:1"
+            "Attributes" = "3:3"
+                "Dialogs"
+                {
+                    "{688940B3-5CA9-4162-8DEE-2993FA9D8CBC}:_C8E6DCE09696418789DC5BA99D5FBECD"
+                    {
+                    "Sequence" = "3:100"
+                    "DisplayName" = "8:Finished"
+                    "UseDynamicProperties" = "11:TRUE"
+                    "IsDependency" = "11:FALSE"
+                    "SourcePath" = "8:<VsdDialogDir>\\VsdFinishedDlg.wid"
+                        "Properties"
+                        {
+                            "BannerBitmap"
+                            {
+                            "Name" = "8:BannerBitmap"
+                            "DisplayName" = "8:#1001"
+                            "Description" = "8:#1101"
+                            "Type" = "3:8"
+                            "ContextData" = "8:Bitmap"
+                            "Attributes" = "3:4"
+                            "Setting" = "3:1"
+                            "UsePlugInResources" = "11:TRUE"
+                            }
+                            "UpdateText"
+                            {
+                            "Name" = "8:UpdateText"
+                            "DisplayName" = "8:#1058"
+                            "Description" = "8:#1158"
+                            "Type" = "3:15"
+                            "ContextData" = "8:"
+                            "Attributes" = "3:0"
+                            "Setting" = "3:1"
+                            "Value" = "8:#1258"
+                            "DefaultValue" = "8:#1258"
+                            "UsePlugInResources" = "11:TRUE"
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -692,12 +654,12 @@
         }
         "ProjectOutput"
         {
-            "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_670F476CDA9D46D6BD301096F75C20B7"
+            "{5259A561-127C-4D43-A0A1-72F10C7B3BF8}:_DC86B167029A4C819CAF722C4640140C"
             {
-            "SourcePath" = "8:..\\SpecMetrix.LoggingService\\obj\\Release\\net8.0\\apphost.exe"
+            "SourcePath" = "8:"
             "TargetName" = "8:"
             "Tag" = "8:"
-            "Folder" = "8:_D0C9CA303A0B4F9B98A8DCAAAC3BC325"
+            "Folder" = "8:_59C5D411CCE049F49EA4414CF3C44719"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -714,7 +676,7 @@
             "ProjectOutputGroupRegister" = "3:1"
             "OutputConfiguration" = "8:"
             "OutputGroupCanonicalName" = "8:PublishItems"
-            "OutputProjectGuid" = "8:{76D37F5E-F072-4643-8686-A0B574BF9C43}"
+            "OutputProjectGuid" = "8:{0BE47547-9A0A-435F-8994-7B00A478C4C5}"
             "ShowKeyOutput" = "11:TRUE"
                 "ExcludeFilters"
                 {

--- a/LoggingService/SpecMetrixLoggingSystem/LoggingServiceUnitTest/LoggingServiceTests.cs
+++ b/LoggingService/SpecMetrixLoggingSystem/LoggingServiceUnitTest/LoggingServiceTests.cs
@@ -13,6 +13,7 @@ public class LogControllerTests
         // Arrange
         var mockLoggingService = new Mock<ILoggingService>();
         var controller = new LogController(mockLoggingService.Object);
+
         var logEntry = new LogEntry
         {
             Namespace = "Unittest",
@@ -21,7 +22,12 @@ public class LogControllerTests
             Message = "Test message",
             MessageTemplate = "Test message",
             RenderedMessage = "Test message",
-            TemplateValues = new Dictionary<string, object>()
+            TemplateValues = new Dictionary<string, object>(),
+            Metadata = new Dictionary<string, string>
+            {
+                // Optional: verify fallback normalization works if EventId isn't set
+                { "eventId", "CFG_PARSE_001" }
+            }
         };
 
         // Act
@@ -31,8 +37,11 @@ public class LogControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.Equal("Log received and processed.", okResult.Value);
 
-        // Verify that EnqueueLog was called once
+        // Verify that EnqueueLog was called once (with some ILogEntry)
         mockLoggingService.Verify(s => s.EnqueueLog(It.IsAny<ILogEntry>()), Times.Once);
+
+        // Optional: ensure the controller normalized EventId from metadata
+        Assert.Equal("CFG_PARSE_001", logEntry.EventId);
     }
 
     [Fact]
@@ -43,7 +52,7 @@ public class LogControllerTests
         var controller = new LogController(mockLoggingService.Object);
 
         // Act
-        var result = controller.ReceiveLog(null);
+        IActionResult result = controller.ReceiveLog(entry: null!);
 
         // Assert
         var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);

--- a/LoggingService/SpecMetrixLoggingSystem/LoggingServiceUnitTest/LoggingServiceUnitTest.csproj
+++ b/LoggingService/SpecMetrixLoggingSystem/LoggingServiceUnitTest/LoggingServiceUnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -14,19 +14,28 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="LoggingService.Extensions" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\LoggingService.Extensions\LoggingService.Extensions.csproj" />
     <ProjectReference Include="..\SpecMetrix.LoggingService\SpecMetrix.LoggingService.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="SpecMetrix.Interfaces">
+      <HintPath>..\..\..\Interfaces\SpecMetrixInterfaces\SpecMetrix.Interfaces\bin\Release\net10.0\SpecMetrix.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="SpecMetrix.Shared">
+      <HintPath>..\..\..\Shared\SpecMetrixShared\SpecMetrix.Shared\bin\Release\net10.0\SpecMetrix.Shared.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <ItemGroup>

--- a/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/LogController.cs
+++ b/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/LogController.cs
@@ -25,8 +25,16 @@ namespace SpecMetrix.LoggingService.Controllers
             if (entry == null)
                 return BadRequest("Cannot have null log.");
 
-            // If SpecMetrix.Shared.Logging.LogEntry implements SpecMetrix.Interfaces.ILogEntry,
-            // this cast is a no-op; otherwise, adapt as needed.
+            // Normalize EventId if not provided: prefer Metadata["eventId"] fallback.
+            // This keeps legacy callers stable while giving modern services a real field for indexing/search.
+            if (string.IsNullOrWhiteSpace(entry.EventId) &&
+                entry.Metadata != null &&
+                entry.Metadata.TryGetValue("eventId", out var ev) &&
+                ev != null)
+            {
+                entry.EventId = ev.ToString();
+            }
+
             _logging.EnqueueLog(entry);
 
             // Keep response simple & fast for callers; they don't need to wait on storage.

--- a/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/LoggingIngestionOptions.cs
+++ b/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/LoggingIngestionOptions.cs
@@ -1,0 +1,28 @@
+﻿namespace SpecMetrix.LoggingService.Services
+{
+    /// <summary>
+    /// Controls behavior of the logging ingestion pipeline.
+    /// </summary>
+    public sealed class LoggingIngestionOptions
+    {
+        /// <summary>
+        /// Maximum number of log entries buffered in memory.
+        /// </summary>
+        public int Capacity { get; set; } = 10_000;
+
+        /// <summary>
+        /// When capacity is exceeded, drop the oldest entries instead of blocking.
+        /// </summary>
+        public bool DropOldest { get; set; } = true;
+
+        /// <summary>
+        /// Never drop critical events (e.g. config ingestion failures).
+        /// </summary>
+        public bool NeverDropCritical { get; set; } = true;
+
+        /// <summary>
+        /// EventId prefix considered critical.
+        /// </summary>
+        public string CriticalEventPrefix { get; set; } = "CFG_";
+    }
+}

--- a/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/LoggingQueueService.cs
+++ b/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/LoggingQueueService.cs
@@ -1,15 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Serilog;
 using Serilog.Events;
 using LoggingService.Extensions.Interfaces;
 using SpecMetrix.Interfaces;               // ILogEntry
-using SpecMetrix.Shared.Logging;           // LogLevel, LogEntry
+using SpecMetrix.Shared.Logging;           // LogEntry
 
 namespace SpecMetrix.LoggingService.Services
 {
@@ -19,30 +19,53 @@ namespace SpecMetrix.LoggingService.Services
     /// </summary>
     public sealed class LoggingQueueService : BackgroundService, ILoggingService
     {
-        // Bounded channel to protect memory in bursty scenarios
-        private readonly Channel<ILogEntry> _channel =
-            Channel.CreateBounded<ILogEntry>(new BoundedChannelOptions(10_000)
+        private readonly Channel<ILogEntry> _channel;
+        private readonly ILogger<LoggingQueueService> _hostLogger;
+        private readonly LoggingIngestionOptions _options;
+
+        public LoggingQueueService(
+            ILogger<LoggingQueueService> hostLogger,
+            IOptions<LoggingIngestionOptions> options)
+        {
+            _hostLogger = hostLogger ?? throw new ArgumentNullException(nameof(hostLogger));
+            _options = options?.Value ?? new LoggingIngestionOptions();
+
+            _channel = Channel.CreateBounded<ILogEntry>(new BoundedChannelOptions(_options.Capacity)
             {
-                FullMode = BoundedChannelFullMode.DropOldest,
+                FullMode = _options.DropOldest ? BoundedChannelFullMode.DropOldest : BoundedChannelFullMode.Wait,
                 SingleReader = true,
                 SingleWriter = false
             });
-
-        private readonly ILogger<LoggingQueueService> _hostLogger;
-
-        public LoggingQueueService(ILogger<LoggingQueueService> hostLogger)
-        {
-            _hostLogger = hostLogger;
         }
 
         public void EnqueueLog(ILogEntry logEntry)
         {
             if (logEntry == null) return;
 
-            // Non-blocking; drops oldest when full (configured above)
+            // Non-blocking: queue behavior controlled by options
             if (!_channel.Writer.TryWrite(logEntry))
             {
-                _hostLogger.LogWarning("Log queue full; dropping oldest entry.");
+                var eventId = ResolveEventId(logEntry);
+                var level = ResolveLevel(logEntry);
+
+                // Never drop critical config ingestion errors: sync fallback write
+                if (_options.NeverDropCritical &&
+                    !string.IsNullOrWhiteSpace(eventId) &&
+                    eventId.StartsWith(_options.CriticalEventPrefix, StringComparison.OrdinalIgnoreCase) &&
+                    (level == LogEventLevel.Error || level == LogEventLevel.Fatal))
+                {
+                    try
+                    {
+                        WriteToSerilog(logEntry);
+                        return;
+                    }
+                    catch (Exception ex)
+                    {
+                        _hostLogger.LogError(ex, "Critical log fallback write failed (EventId={EventId}).", eventId);
+                    }
+                }
+
+                _hostLogger.LogWarning("Log queue full; dropping entry. EventId={EventId}", eventId ?? "");
             }
         }
 
@@ -76,11 +99,14 @@ namespace SpecMetrix.LoggingService.Services
 
         private static void WriteToSerilog(ILogEntry e)
         {
-            // If the caller already uses the shared DTO, we can access rich fields.
+            // If the caller uses the shared DTO, we can access rich fields.
             if (e is LogEntry dto)
             {
                 var level = MapLevel(dto.Level);
+                var eventId = ResolveEventId(dto);
+
                 var logger = Log.ForContext("Namespace", dto.Namespace ?? "SA")
+                                .ForContext("EventId", eventId ?? "")
                                 .ForContext("MachineName", dto.MachineName ?? "")
                                 .ForContext("Code", dto.Code)
                                 .ForContext("Process", dto.Process ?? "")
@@ -91,22 +117,18 @@ namespace SpecMetrix.LoggingService.Services
                 // Attach Metadata/TemplateValues when present
                 if (dto.Metadata is { Count: > 0 })
                     logger = logger.ForContext("Metadata", dto.Metadata, destructureObjects: true);
+
                 if (dto.TemplateValues is { Count: > 0 })
                     logger = logger.ForContext("TemplateValues", dto.TemplateValues, destructureObjects: true);
 
-                // Prefer message template + values; otherwise use rendered/message
-                if (!string.IsNullOrWhiteSpace(dto.MessageTemplate) && dto.TemplateValues is { Count: > 0 })
+                // IMPORTANT:
+                // Do NOT pass dictionary template values as Serilog template args; it will not bind as expected.
+                // Keep structure in Metadata/TemplateValues and log a rendered message string.
+                var msg = ResolveRenderedMessage(dto);
+
+                if (!string.IsNullOrWhiteSpace(msg))
                 {
-                    // Render with values as a single object so Serilog keeps structure
-                    logger.Write(level, dto.MessageTemplate, dto.TemplateValues);
-                }
-                else if (!string.IsNullOrWhiteSpace(dto.Message))
-                {
-                    logger.Write(level, "{Message}", dto.Message);
-                }
-                else if (!string.IsNullOrWhiteSpace(dto.RenderedMessage))
-                {
-                    logger.Write(level, "{Message}", dto.RenderedMessage);
+                    logger.Write(level, "{Message}", msg);
                 }
                 else
                 {
@@ -118,29 +140,86 @@ namespace SpecMetrix.LoggingService.Services
             }
 
             // Generic fallback for any ILogEntry (unknown runtime type)
-            // Serialize the object graph to preserve detail.
             loggerFallback(e);
         }
 
         private static void loggerFallback(ILogEntry e)
         {
-            var lvl = LogEventLevel.Information;
-            try
-            {
-                // If the interface exposes Level, try to map it
-                var levelProp = e.GetType().GetProperty("Level");
-                if (levelProp != null)
-                {
-                    var v = levelProp.GetValue(e, null);
-                    if (v is SpecMetrix.Interfaces.LogLevel sharedLevel) lvl = MapLevel(sharedLevel);
-                    else if (v is string s && Enum.TryParse<SpecMetrix.Interfaces.LogLevel>(s, true, out var parsed))
-                        lvl = MapLevel(parsed);
-                }
-            }
-            catch { /* ignore */ }
+            var lvl = ResolveLevel(e);
+            var eventId = ResolveEventId(e);
 
             Log.ForContext("EntryType", e.GetType().FullName ?? "Unknown")
+               .ForContext("EventId", eventId ?? "")
                .Write(lvl, "{@Entry}", e);
+        }
+
+        private static LogEventLevel ResolveLevel(ILogEntry e)
+        {
+            try
+            {
+                if (e is LogEntry dto) return MapLevel(dto.Level);
+
+                var levelProp = e.GetType().GetProperty("Level");
+                if (levelProp == null) return LogEventLevel.Information;
+
+                var v = levelProp.GetValue(e, null);
+                if (v is SpecMetrix.Interfaces.LogLevel sharedLevel) return MapLevel(sharedLevel);
+
+                if (v is string s && Enum.TryParse<SpecMetrix.Interfaces.LogLevel>(s, true, out var parsed))
+                    return MapLevel(parsed);
+            }
+            catch { }
+
+            return LogEventLevel.Information;
+        }
+
+        private static string? ResolveEventId(ILogEntry e)
+        {
+            // Preferred: first-class EventId property
+            try
+            {
+                var p = e.GetType().GetProperty("EventId");
+                if (p != null)
+                {
+                    var v = p.GetValue(e, null) as string;
+                    if (!string.IsNullOrWhiteSpace(v)) return v;
+                }
+            }
+            catch { }
+
+            // Fallback: Metadata["eventId"]
+            if (e is LogEntry dto && dto.Metadata != null)
+            {
+                if (dto.Metadata.TryGetValue("eventId", out var ev) && ev != null)
+                {
+                    var s = ev.ToString();
+                    if (!string.IsNullOrWhiteSpace(s)) return s;
+                }
+            }
+
+            return null;
+        }
+
+        private static string? ResolveRenderedMessage(LogEntry dto)
+        {
+            if (!string.IsNullOrWhiteSpace(dto.Message)) return dto.Message;
+            if (!string.IsNullOrWhiteSpace(dto.RenderedMessage)) return dto.RenderedMessage;
+
+            // If we have a template, try to render it deterministically (best-effort).
+            if (!string.IsNullOrWhiteSpace(dto.MessageTemplate) &&
+                dto.TemplateValues is { Count: > 0 })
+            {
+                var rendered = dto.MessageTemplate;
+                foreach (var kv in dto.TemplateValues)
+                {
+                    rendered = rendered.Replace("{" + kv.Key + "}", kv.Value?.ToString() ?? string.Empty);
+                }
+                return rendered;
+            }
+
+            if (!string.IsNullOrWhiteSpace(dto.MessageTemplate)) return dto.MessageTemplate;
+
+            return null;
         }
 
         private static LogEventLevel MapLevel(SpecMetrix.Interfaces.LogLevel level)

--- a/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/LoggingStorageInitializer.cs
+++ b/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/LoggingStorageInitializer.cs
@@ -1,0 +1,42 @@
+﻿using LoggingService;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace SpecMetrix.LoggingService.Services
+{
+    /// <summary>
+    /// Ensures logging storage (MongoDB collections) exists at startup.
+    /// </summary>
+    public sealed class LoggingStorageInitializer : IHostedService
+    {
+        private readonly MongoLogService _mongo;
+        private readonly ILogger<LoggingStorageInitializer> _logger;
+
+        public LoggingStorageInitializer(
+            MongoLogService mongo,
+            ILogger<LoggingStorageInitializer> logger)
+        {
+            _mongo = mongo;
+            _logger = logger;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                _mongo.EnsureDatabaseAndCollection();
+                _mongo.EnsureHealthCollection();
+                _logger.LogInformation("Logging storage initialized.");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogCritical(ex, "Logging storage initialization failed.");
+                throw;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/MongoLogService.cs
+++ b/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/MongoLogService.cs
@@ -31,8 +31,9 @@ namespace LoggingService
             _database = client.GetDatabase(_config.DatabaseName);
             _activeDatabaseName = _config.DatabaseName;
 
-            EnsureDatabaseAndCollection();
-            EnsureHealthCollection();
+            // NOTE:
+            // Do NOT call EnsureDatabaseAndCollection / EnsureHealthCollection here.
+            // Startup initialization is handled by LoggingStorageInitializer for deterministic DI behavior.
         }
 
         private DatabaseConfig? TryConnect(string? dbKey, Dictionary<string, DatabaseConfig> configs)
@@ -113,7 +114,7 @@ namespace LoggingService
             Console.WriteLine($"MongoDB Time-Series Collection '{_config.CollectionName}' Created Successfully in '{_activeDatabaseName}'");
         }
 
-        private void EnsureHealthCollection()
+        public void EnsureHealthCollection()
         {
             var collections = _database.ListCollectionNames().ToList();
             if (!collections.Contains(_healthCollectionName))

--- a/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/Program.cs
+++ b/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/Program.cs
@@ -11,6 +11,7 @@ using LoggingService.Configuration;
 using LoggingService.Extensions;
 using LoggingService.Extensions.Interfaces;
 using LoggingService.Health; // MongoWriteHealthCheck
+using SpecMetrix.LoggingService.Services; // LoggingQueueService, LoggingIngestionOptions, LoggingStorageInitializer
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -46,14 +47,18 @@ builder.Host.UseSerilog();
 builder.Services.AddSingleton<MongoLogService>();
 builder.Services.AddSingleton<IMongoWriteVerifier, MongoLogService>();
 
-builder.Services.AddSingleton<SpecMetrix.LoggingService.Services.LoggingQueueService>();
-builder.Services.AddSingleton<ILoggingService>(sp => sp.GetRequiredService<SpecMetrix.LoggingService.Services.LoggingQueueService>());
-builder.Services.AddHostedService(sp => sp.GetRequiredService<SpecMetrix.LoggingService.Services.LoggingQueueService>());
+// --- Ingestion pipeline options (DI-configurable) ---
+builder.Services.Configure<LoggingIngestionOptions>(builder.Configuration.GetSection("Config:Logging:Ingestion"));
 
-// --- Background pipeline (if you’re consuming from a queue, keep this) ---
-builder.Services.AddHostedService<LogProcessingService>();
+// --- Queue-based ingestion pipeline: ONE hosted service ---
+builder.Services.AddSingleton<LoggingQueueService>();
+builder.Services.AddSingleton<ILoggingService>(sp => sp.GetRequiredService<LoggingQueueService>());
+builder.Services.AddHostedService(sp => sp.GetRequiredService<LoggingQueueService>());
 
-// --- Controllers (for /api/logs) & JSON enum casing ---
+// --- Deterministic Mongo init ONCE at startup ---
+builder.Services.AddHostedService<LoggingStorageInitializer>();
+
+// --- Controllers & JSON enum casing ---
 builder.Services.AddControllers().AddJsonOptions(options =>
 {
     options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
@@ -69,19 +74,12 @@ builder.Services.AddHealthChecks()
 
 var app = builder.Build();
 
-// Ensure database/collection exists up front
-using (var scope = app.Services.CreateScope())
-{
-    var mongo = scope.ServiceProvider.GetRequiredService<MongoLogService>();
-    mongo.EnsureDatabaseAndCollection();
-}
-
 if (app.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();
 }
 
-// Map controllers (this picks up LogsController at /api/logs)
+// Map controllers (LogController -> /api/log)
 app.MapControllers();
 
 // Health endpoint

--- a/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/SpecMetrix.LoggingService.csproj
+++ b/LoggingService/SpecMetrixLoggingSystem/SpecMetrix.LoggingService/SpecMetrix.LoggingService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>dotnet-SpecMetrix.LoggingService-6a89c6a2-8175-414d-9ee2-82a4df103573</UserSecretsId>
@@ -9,26 +9,34 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.3" />
-		<PackageReference Include="MongoDB.Driver" Version="3.3.0" />
-		<PackageReference Include="Serilog" Version="4.2.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.2" />
+		<PackageReference Include="MongoDB.Driver" Version="3.6.0" />
+		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.Deduplication" Version="1.0.2" />
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Serilog.Sinks.EventLog" Version="4.0.0" />
-		<PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-		<PackageReference Include="Serilog.Sinks.MongoDB" Version="7.0.0" />
-		<PackageReference Include="SpecMetrix.Shared" Version="0.1.11" />
+		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+		<PackageReference Include="Serilog.Sinks.MongoDB" Version="7.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\LoggingService.Configuration\LoggingService.Configuration.csproj" />
 	  <ProjectReference Include="..\LoggingService.Extensions\LoggingService.Extensions.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Reference Include="SpecMetrix.Interfaces">
+	    <HintPath>..\..\..\Interfaces\SpecMetrixInterfaces\SpecMetrix.Interfaces\bin\Release\net10.0\SpecMetrix.Interfaces.dll</HintPath>
+	  </Reference>
+	  <Reference Include="SpecMetrix.Shared">
+	    <HintPath>..\..\..\Shared\SpecMetrixShared\SpecMetrix.Shared\bin\Release\net10.0\SpecMetrix.Shared.dll</HintPath>
+	  </Reference>
 	</ItemGroup>
 
 </Project>

--- a/LoggingService/SpecMetrixLoggingSystem/SpecMetrixLoggingSystem.sln
+++ b/LoggingService/SpecMetrixLoggingSystem/SpecMetrixLoggingSystem.sln
@@ -7,11 +7,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpecMetrix.LoggingService",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoggingServiceUnitTest", "LoggingServiceUnitTest\LoggingServiceUnitTest.csproj", "{FD7679BC-4E12-458C-8A28-1F5DC76A3228}"
 EndProject
-Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "LoggingServiceSetup", "LoggingServiceSetup\LoggingServiceSetup.vdproj", "{425AB6FC-F3CE-4FFE-9AA9-EC3151FF8015}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoggingService.Configuration", "LoggingService.Configuration\LoggingService.Configuration.csproj", "{0BE47547-9A0A-435F-8994-7B00A478C4C5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoggingService.Extensions", "LoggingService.Extensions\LoggingService.Extensions.csproj", "{F44AC443-6873-45E8-A951-F4124793F232}"
+EndProject
+Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "LoggingServiceSetup", "LoggingServiceSetup\LoggingServiceSetup.vdproj", "{B7B01FBA-492A-ACBF-A90C-EF20AE62E3A6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,8 +27,6 @@ Global
 		{FD7679BC-4E12-458C-8A28-1F5DC76A3228}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD7679BC-4E12-458C-8A28-1F5DC76A3228}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD7679BC-4E12-458C-8A28-1F5DC76A3228}.Release|Any CPU.Build.0 = Release|Any CPU
-		{425AB6FC-F3CE-4FFE-9AA9-EC3151FF8015}.Debug|Any CPU.ActiveCfg = Debug
-		{425AB6FC-F3CE-4FFE-9AA9-EC3151FF8015}.Release|Any CPU.ActiveCfg = Release
 		{0BE47547-9A0A-435F-8994-7B00A478C4C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0BE47547-9A0A-435F-8994-7B00A478C4C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BE47547-9A0A-435F-8994-7B00A478C4C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -37,6 +35,8 @@ Global
 		{F44AC443-6873-45E8-A951-F4124793F232}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F44AC443-6873-45E8-A951-F4124793F232}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F44AC443-6873-45E8-A951-F4124793F232}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7B01FBA-492A-ACBF-A90C-EF20AE62E3A6}.Debug|Any CPU.ActiveCfg = Debug
+		{B7B01FBA-492A-ACBF-A90C-EF20AE62E3A6}.Release|Any CPU.ActiveCfg = Release
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Shared/SpecMetrixShared/SpecMetrix.Shared/Logging/LogEntry.cs
+++ b/Shared/SpecMetrixShared/SpecMetrix.Shared/Logging/LogEntry.cs
@@ -7,6 +7,8 @@ namespace SpecMetrix.Shared.Logging;
 /// </summary>
 public class LogEntry : ILogEntry
 {
+    public string? EventId { get; set; }
+
     public Guid LogId { get; set; }
 
     public required string Namespace { get; set; }

--- a/Shared/SpecMetrixShared/SpecMetrix.Shared/Logging/MongoLogEntry.cs
+++ b/Shared/SpecMetrixShared/SpecMetrix.Shared/Logging/MongoLogEntry.cs
@@ -5,211 +5,212 @@ using SpecMetrix.Interfaces;
 namespace SpecMetrix.Shared.Logging
 {
     /// <summary>
-    /// Log Entry for SpecMetrix systems
+    /// MongoDB persisted log entry for SpecMetrix systems.
+    /// 
+    /// IMPORTANT:
+    /// - We store rich Serilog properties inside the "Properties" BsonDocument.
+    /// - The interface fields (Namespace, MachineName, Process, etc.) are implemented as proxy
+    ///   accessors into that document.
+    /// - Those proxy properties are marked [BsonIgnore] so Mongo does NOT persist them twice
+    ///   (top-level + inside Properties) which can cause clobbering during deserialize.
     /// </summary>
     [BsonIgnoreExtraElements]
-    public class MongoLogEntry : ILogEntry
+    public sealed class MongoLogEntry : ILogEntry
     {
-        [BsonId] // Maps to MongoDB's _id field
+        public MongoLogEntry()
+        {
+            // Ensure non-null defaults to satisfy ILogEntry contract and tolerate partial inputs.
+            Properties = new BsonDocument();
+            Message = string.Empty;
+            MessageTemplate = string.Empty;
+            RenderedMessage = string.Empty;
+            TemplateValues = new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Stable event taxonomy identifier (e.g. CFG_PARSE_101).
+        /// </summary>
+        public string? EventId { get; set; }
+
+        /// <summary>
+        /// MongoDB internal identifier.
+        /// </summary>
+        [BsonId] // Maps to MongoDB "_id"
         public ObjectId Id { get; set; }
 
+        /// <summary>
+        /// Unique identifier for the log entry (SpecMetrix contract).
+        /// </summary>
         public Guid LogId { get; set; }
 
-        public required string Message { get; set; }
+        /// <summary>
+        /// Timestamp the event occurred.
+        /// </summary>
+        public DateTime Timestamp { get; set; }
 
+        /// <summary>
+        /// Logging level.
+        /// </summary>
+        public LogLevel Level { get; set; }
+
+        /// <summary>
+        /// Primary message (human readable).
+        /// </summary>
+        public string Message { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Number of repetitive occurrences without stopping.
+        /// </summary>
+        public ulong Occurrences { get; set; }
+
+        /// <summary>
+        /// Optional contextual data (string,string per current ILogEntry contract).
+        /// </summary>
+        public IDictionary<string, string>? Metadata { get; set; }
+
+        /// <summary>
+        /// Exception message (optional).
+        /// </summary>
+        public string? ExceptionMessage { get; set; }
+
+        /// <summary>
+        /// Stack trace (optional).
+        /// </summary>
+        public string? StackTrace { get; set; }
+
+        /// <summary>
+        /// Serilog message template (may be empty).
+        /// </summary>
+        public string MessageTemplate { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Serilog template values (non-null per ILogEntry contract).
+        /// </summary>
+        public IDictionary<string, object> TemplateValues { get; set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Rendered message (may be empty).
+        /// </summary>
+        public string RenderedMessage { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Captured Serilog "Properties" (structured event payload).
+        /// This is the authoritative store for fields like Namespace/MachineName/Process/etc.
+        /// </summary>
         [BsonElement("Properties")]
         public BsonDocument Properties { get; set; } = new BsonDocument();
 
-        public required string MessageTemplate { get; set; }
+        // --------------------------
+        // Proxy properties into Properties BsonDocument
+        // These are part of ILogEntry but should NOT be persisted as top-level fields.
+        // --------------------------
 
-        public required IDictionary<string, object> TemplateValues { get; set; }
-
-        public required string RenderedMessage { get; set; }
-
-        public DateTime Timestamp { get; set; }
-
+        [BsonIgnore]
         public string Namespace
         {
-            get
-            {
-                if (Properties.Contains("Namespace") && Properties["Namespace"].IsString)
-                {
-                    return Properties["Namespace"].AsString;
-                }
-                return string.Empty;
-            }
-            set
-            {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    Properties["Namespace"] = value;
-                }
-                else
-                {
-                    Properties.Remove("Namespace");
-                }
-            }
+            get => GetString("Namespace") ?? string.Empty;
+            set => SetStringOrRemove("Namespace", value);
         }
 
+        [BsonIgnore]
         public string MachineName
         {
-            get
-            {
-                if (Properties.Contains("MachineName") && Properties["MachineName"].IsString)
-                {
-                    return Properties["MachineName"].AsString;
-                }
-                return string.Empty;
-            }
-            set
-            {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    Properties["MachineName"] = value;
-                }
-                else
-                {
-                    Properties.Remove("MachineName");
-                }
-            }
+            get => GetString("MachineName") ?? string.Empty;
+            set => SetStringOrRemove("MachineName", value);
         }
 
+        [BsonIgnore]
         public int Code
         {
-            get
-            {
-                if (Properties.Contains("Code") && Properties["Code"].IsInt32)
-                {
-                    return Properties["Code"].AsInt32;
-                }
-                return default;
-            }
-            set => Properties["Code"] = value;
+            get => GetInt32("Code");
+            set => EnsureProperties()["Code"] = value;
         }
 
+        [BsonIgnore]
         public string Process
         {
-            get
-            {
-                if (Properties.Contains("Process") && Properties["Process"].IsString)
-                {
-                    return Properties["Process"].AsString;
-                }
-                return string.Empty;
-            }
-            set
-            {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    Properties["Process"] = value;
-                }
-                else
-                {
-                    Properties.Remove("Process");
-                }
-            }
+            get => GetString("Process") ?? string.Empty;
+            set => SetStringOrRemove("Process", value);
         }
 
+        [BsonIgnore]
         public string? ClassMethod
         {
-            get
-            {
-                if (Properties.Contains("ClassMethod") && Properties["ClassMethod"].IsString)
-                {
-                    return Properties["ClassMethod"].AsString;
-                }
-                return null;
-            }
-            set
-            {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    Properties["ClassMethod"] = value;
-                }
-                else
-                {
-                    Properties.Remove("ClassMethod");
-                }
-            }
+            get => GetString("ClassMethod");
+            set => SetStringOrRemove("ClassMethod", value);
         }
 
-        public ulong Occurrences { get; set; }
-
-        public IDictionary<string, string>? Metadata { get; set; }
-
+        [BsonIgnore]
         public string? Source
         {
-            get
-            {
-                if (Properties.Contains("Source") && Properties["Source"].IsString)
-                {
-                    return Properties["Source"].AsString;
-                }
-                return null;
-            }
-            set
-            {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    Properties["Source"] = value;
-                }
-                else
-                {
-                    Properties.Remove("Source");
-                }
-            }
+            get => GetString("Source");
+            set => SetStringOrRemove("Source", value);
         }
 
+        [BsonIgnore]
         public LogCategory? Category
         {
             get
             {
-                if (Properties.Contains("Category") && Properties["Category"].IsString)
-                {
-                    return Enum.TryParse(Properties["Category"].AsString, out LogCategory category) ? category : (LogCategory?)null;
-                }
-                return null;
+                var s = GetString("Category");
+                if (string.IsNullOrWhiteSpace(s)) return null;
+                return Enum.TryParse(s, out LogCategory cat) ? cat : (LogCategory?)null;
             }
             set
             {
                 if (value.HasValue)
-                {
-                    Properties["Category"] = value.Value.ToString();
-                }
+                    EnsureProperties()["Category"] = value.Value.ToString();
                 else
-                {
-                    Properties.Remove("Category");
-                }
+                    EnsureProperties().Remove("Category");
             }
         }
 
-        public string? ExceptionMessage { get; set; }
-
-        public string? StackTrace { get; set; }
-
+        [BsonIgnore]
         public string? DeviceName
         {
-            get
-            {
-                if (Properties.Contains("DeviceName") && Properties["DeviceName"].IsString)
-                {
-                    return Properties["DeviceName"].AsString;
-                }
-                return null;
-            }
-            set
-            {
-                if (!string.IsNullOrEmpty(value))
-                {
-                    Properties["DeviceName"] = value;
-                }
-                else
-                {
-                    Properties.Remove("DeviceName");
-                }
-            }
+            get => GetString("DeviceName");
+            set => SetStringOrRemove("DeviceName", value);
         }
 
-        public LogLevel Level { get; set; }
+        // --------------------------
+        // Internal helpers
+        // --------------------------
+
+        private BsonDocument EnsureProperties()
+        {
+            Properties ??= new BsonDocument();
+            return Properties;
+        }
+
+        private string? GetString(string key)
+        {
+            var doc = EnsureProperties();
+            if (doc.Contains(key) && doc[key].IsString)
+                return doc[key].AsString;
+
+            return null;
+        }
+
+        private int GetInt32(string key)
+        {
+            var doc = EnsureProperties();
+            if (doc.Contains(key))
+            {
+                var v = doc[key];
+                if (v.IsInt32) return v.AsInt32;
+                if (v.IsInt64) return checked((int)v.AsInt64);
+                if (v.IsDouble) return checked((int)v.AsDouble);
+            }
+            return default;
+        }
+
+        private void SetStringOrRemove(string key, string? value)
+        {
+            var doc = EnsureProperties();
+            if (!string.IsNullOrWhiteSpace(value))
+                doc[key] = value!;
+            else
+                doc.Remove(key);
+        }
     }
 }

--- a/Shared/SpecMetrixShared/SpecMetrix.Shared/SpecMetrix.Shared.csproj
+++ b/Shared/SpecMetrixShared/SpecMetrix.Shared/SpecMetrix.Shared.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	  
 	  <!-- NuGet Package Info -->
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <PackageId>SpecMetrix.Shared</PackageId>
-	  <Version>0.1.11</Version>
+	  <Version>0.1.12</Version>
 	  <Authors>Jason Jelks</Authors>
 	  <Company>SpecMetrix</Company>
 	  <Description>Shared utilities and classes for SpecMetrix Systems</Description>
@@ -19,8 +19,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="3.1.0" />
-    <PackageReference Include="SpecMetrix.Interfaces" Version="0.1.11" />
+    <PackageReference Include="MongoDB.Bson" Version="3.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="SpecMetrix.Interfaces">
+      <HintPath>..\..\..\Interfaces\SpecMetrixInterfaces\SpecMetrix.Interfaces\bin\Release\net10.0\SpecMetrix.Interfaces.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/SpecMetrixDataService/SpecMetrix.DataService/MongoDataService.cs
+++ b/SpecMetrixDataService/SpecMetrix.DataService/MongoDataService.cs
@@ -1,48 +1,53 @@
-﻿using MongoDB.Bson;
-using MongoDB.Driver;
+﻿using MongoDB.Driver;
 using SpecMetrix.Interfaces;
 using SpecMetrix.Shared.Logging;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace SpecMetrix.DataService
 {
-    /*
-    * 12.05.2024 jj - Changed all MongoDataService features to use MongoLogEntry (SpecMetrix.Shared 0.1.10 required)
-    *                 This is to remove conflicts for Serilog writes to MongoDB using LogEntry class.
-    *                 Note However that as of this release (0.1.10) the returning interface is still based on ILogEntry
-    *                 we may need to add a IMongoLogEntry for the consumers to manage correct implementation of all data
-    */
-
-    public class MongoDataService : IDataService
+    public sealed class MongoDataService : IDataService<MongoLogEntry>
     {
+        private const string DefaultDatabaseName = "Logging";
+        private const string DefaultCollectionName = "Logs";
 
-        private readonly IMongoCollection<MongoLogEntry> _mongoLogCollection; // used for read processing
+        private readonly IMongoCollection<MongoLogEntry> _mongoLogCollection;
 
         public MongoDataService(IMongoClient mongoClient)
         {
-            var database = mongoClient.GetDatabase("Logging");
-            _mongoLogCollection = database.GetCollection<MongoLogEntry>("Logs"); // added _mongoLogCollection
+            if (mongoClient == null) throw new ArgumentNullException(nameof(mongoClient));
+
+            var database = mongoClient.GetDatabase(DefaultDatabaseName);
+            _mongoLogCollection = database.GetCollection<MongoLogEntry>(DefaultCollectionName);
         }
 
-        public async Task WriteLogAsync(ILogEntry MongoLogEntry)
+        public async Task WriteLogAsync(MongoLogEntry entry)
         {
-            await _mongoLogCollection.InsertOneAsync((MongoLogEntry)MongoLogEntry); // Cast IMongoLogEntry to MongoLogEntry
+            if (entry == null) throw new ArgumentNullException(nameof(entry));
+            await _mongoLogCollection.InsertOneAsync(entry).ConfigureAwait(false);
         }
 
-        public async Task WriteLogsAsync(IEnumerable<ILogEntry> logEntries)
+        public async Task WriteLogsAsync(IEnumerable<MongoLogEntry> entries)
         {
-            await _mongoLogCollection.InsertManyAsync((IEnumerable<MongoLogEntry>)logEntries); // Cast IEnumerable<IMongoLogEntry> to IEnumerable<MongoLogEntry>
+            if (entries == null) throw new ArgumentNullException(nameof(entries));
+
+            var list = entries as IList<MongoLogEntry> ?? entries.ToList();
+            if (list.Count == 0) return;
+
+            await _mongoLogCollection.InsertManyAsync(list).ConfigureAwait(false);
         }
 
-        public async Task<IEnumerable<ILogEntry>> ReadLogsAsync(LogQueryOptions queryOptions)
+        public async Task<IEnumerable<MongoLogEntry>> ReadLogsAsync(LogQueryOptions queryOptions)
         {
+            if (queryOptions == null) throw new ArgumentNullException(nameof(queryOptions));
+
             try
             {
                 var filterBuilder = Builders<MongoLogEntry>.Filter;
-                var filter = filterBuilder.Empty; // Default to no filters
+                var filter = filterBuilder.Empty;
 
-                // Apply filters based on query options
                 if (queryOptions.StartDate.HasValue)
                     filter &= filterBuilder.Gte(log => log.Timestamp, queryOptions.StartDate.Value);
 
@@ -69,22 +74,19 @@ namespace SpecMetrix.DataService
 
                 var query = _mongoLogCollection.Find(filter);
 
-                // Apply sorting and limiting if specified
                 if (queryOptions.HowManyLogsToGet.HasValue)
                 {
                     query = query.SortByDescending(log => log.Timestamp)
                                  .Limit(queryOptions.HowManyLogsToGet.Value);
                 }
 
-                return await query.ToListAsync();
+                return await query.ToListAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                // Log the exception for debugging
                 Console.WriteLine($"Error while reading logs: {ex.Message}");
-                return []; // returns empty IEnumerable<IMongoLogEntry>
+                return Enumerable.Empty<MongoLogEntry>();
             }
         }
-
     }
 }

--- a/SpecMetrixDataService/SpecMetrix.DataService/SpecMetrix.DataService.csproj
+++ b/SpecMetrixDataService/SpecMetrix.DataService/SpecMetrix.DataService.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	  
 	<!-- NuGet Package Info -->
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageId>SpecMetrix.DataService</PackageId>
-	<Version>0.1.11</Version>
+	<Version>0.1.12</Version>
 	<Authors>Jason Jelks</Authors>
 	<Company>SpecMetrix</Company>
 	<Description>SpecMetrix DataServices</Description>
@@ -19,8 +19,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
-    <PackageReference Include="SpecMetrix.Shared" Version="0.1.11" />
+    <PackageReference Include="MongoDB.Driver" Version="3.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="SpecMetrix.Interfaces">
+      <HintPath>..\..\Interfaces\SpecMetrixInterfaces\SpecMetrix.Interfaces\bin\Release\net10.0\SpecMetrix.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="SpecMetrix.Shared">
+      <HintPath>..\..\Shared\SpecMetrixShared\SpecMetrix.Shared\bin\Release\net10.0\SpecMetrix.Shared.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Summary

Upgrade the solution and projects from .NET 8 -> .NET 10 and update NuGet dependencies to compatible versions.
Apply code fixes required by the SDK bump (API replacements, obsolete APIs, compiler warnings).
Harden runtime behavior and dependency management (dependency versions, input validation, error handling).
Update build and developer scripts (global.json, CI/workflows, Dockerfile(s), PowerShell scripts) to target .NET 10.
Why this change

Move to the latest LTS-capable runtime to gain performance, security, and tooling improvements.
Reduce technical debt from obsolete APIs and address new compiler/runtime guidance.
Ensure CI, containers, and developer machines all target a consistent, supported SDK/runtime.
Notable changes included

Target frameworks in project files updated to net10.0 (all projects).
NuGet package references updated where needed to .NET 10-compatible versions.
Replaced or refactored uses of APIs deprecated in newer SDKs to eliminate build warnings/errors.
Updated Docker base images to .NET 10 (Dockerfile(s)).
Updated global.json (if present) to reference .NET 10 SDK version.
Adjusted GitHub Actions/workflows to use dotnet/SDK: 10.x and updated CI steps to restore/build/test with net10.0.
Updated PowerShell helper scripts to use the new dotnet commands/paths where applicable.
Added/updated input validation and improved error handling around areas that surfaced issues during the upgrade.
Minor README/docs updates mentioning .NET 10 as the required SDK/runtime.
Migration notes for maintainers / developers

Install .NET 10 SDK on developer machines: https://dotnet.microsoft.com/en-us/download
If you use global.json, ensure your SDK version matches the project's global.json (or update accordingly).
Run:
dotnet restore
dotnet build --configuration Release
dotnet test (run test suite)
If you run using Docker, rebuild images to pick up updated base images:
docker build -t specmetrixlog:latest .
Confirm any external tooling (CI runners, container hosts) are updated to support .NET 10.
Potential breaking changes / risks

Runtime requirement change: systems that only have .NET 8 or older will not be able to run the built artifacts.
Some third-party packages may have behavior changes after the version bumps — please review runtime logs carefully.
If any consumers rely on implementation details that changed, minor behavior differences are possible; validate integration flows (especially MongoDB write/read paths).
Testing & validation performed / requested

Please allow CI to run the full build/test matrix. Reviewers should:
Verify the project builds cleanly on net10.0.
Run the full unit/integration test suite locally or in CI.
Run the service locally and exercise typical workflows (ingest messages, verify writes to MongoDB).
Validate Docker image builds and container startup.
Confirm logging, configuration, and any environment variable behavior remains consistent.
Files & areas to review closely

.sln / .csproj files (target frameworks, package references)
Dockerfile(s) and container-related scripts
GitHub Actions workflows and any CI scripts
Any code changed to replace deprecated APIs / to handle new runtime behaviors
PowerShell scripts updated for SDK/runtime changes
Notes for merging / rollout

Merge when CI is green and reviewers have validated local build/tests.
Rollout to staging first to confirm integration with MongoDB and downstream consumers before production.
Keep a rollback plan (revert to the previous commit and redeploy) if unexpected runtime issues are observed.
If you'd like, I can:

Add a short migration checklist into the README or CONTRIBUTING.md.
Produce a changelog entry summarizing these upgrade items for release notes.
Checklist for reviewer

 CI builds and tests pass on net10.0
 Local build & tests pass with .NET 10 SDK
 Container images build and start correctly
 MongoDB integration validated
 No remaining critical warnings or deprecated API usages